### PR TITLE
Fix (tests): Fix test entrypoint script not exiting with non-zero exit code on any failed test

### DIFF
--- a/test/test.ps1
+++ b/test/test.ps1
@@ -48,7 +48,7 @@ if ($Tag) {
         "$( $res2.FailedCount ) integration tests failed." | Write-Host
     }
 
-    if ($res -and $res.FailedCount -gt 0 -or $res2 -and $res2.FailedCount) {
+    if (($res -and $res.FailedCount -gt 0) -or ($res2 -and $res2.FailedCount)) {
         throw
     }
 }


### PR DESCRIPTION
Related: #4 