### PR TITLE
Fix (tests): Use random password to reduce server rate limiting causing failed tests

### DIFF
--- a/src/PSSourceQuery/public/GoldSourceRcon.Tests.ps1
+++ b/src/PSSourceQuery/public/GoldSourceRcon.Tests.ps1
@@ -52,7 +52,7 @@ Describe "GoldSourceRcon" -Tag 'Unit' {
         }
 
         It 'Fails when rcon password is wrong' {
-            $password = 'foo'
+            $password = "$( Get-Random -Minimum 1 -Maximum 1000000 )"
             $command = 'status'
             $ErrorActionPreference = 'Stop'
             Mock Write-Verbose {}

--- a/src/PSSourceQuery/public/SourceRcon.Tests.ps1
+++ b/src/PSSourceQuery/public/SourceRcon.Tests.ps1
@@ -52,7 +52,7 @@ Describe "SourceRcon" -Tag 'Unit' {
         }
 
         It 'Fails when rcon password is wrong' {
-            $password = 'foo'
+            $password = "$( Get-Random -Minimum 1 -Maximum 1000000 )"
             $command = 'status'
             $ErrorActionPreference = 'Stop'
             Mock Write-Verbose {}


### PR DESCRIPTION


This fixes false negatives (incorrect test failures).